### PR TITLE
Added switch for mac users

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -7,7 +7,12 @@ ACLOCAL="aclocal"
 AUTOHEADER="autoheader"
 AUTOMAKE="automake"
 AUTOCONF="autoconf"
-LIBTOOLIZE="libtoolize"
+if [[ `uname` == *"Darwin"* ]]; then
+        echo "It's a Mac, we use glibtoolize instead of libtoolize"
+        LIBTOOLIZE="glibtoolize"
+else
+        LIBTOOLIZE="libtoolize"
+fi
 
 # Cleanup
 echo "Cleanup"


### PR DESCRIPTION
I realized i could not run ./autogen.sh on mac. Libtoolize on Mac is installed, but it does NOT include Mac specific changes. If a Mac users wants to run ./autogen.sh it just fails with: libtoolize: command not found. 

To solve use, Apple gave us "glibtoolize" with specific changes for Mac.

The complete building on Mac is very different. I could fix some problems but its not building. Maybe we can fix it together?